### PR TITLE
[MRG] feat(Credit card font): Uses Averta in Credit Card field

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -546,16 +546,16 @@ export default {
       stripeOptions: {
         // see https://stripe.com/docs/stripe.js#element-options for details
         elements: {
-          // fonts: [
-          //   {
-          //     family: "Averta",
-          //     src:
-          //       'url("https://my.skribble.com/_nuxt/fonts/48cfe38.woff2") format("woff2")',
-          //     style: "normal",
-          //     weight: 400,
-          //     display: "swap",
-          //   },
-          // ],
+          fonts: [
+            {
+              family: 'Averta',
+              src:
+                'url("https://my.skribble.com/_nuxt/fonts/48cfe38.woff2") format("woff2")',
+              style: 'normal',
+              weight: 400,
+              display: 'swap',
+            },
+          ],
         },
         style: {
           base: {


### PR DESCRIPTION
It's the least hacky way of having the correct font on the stripe credit card field (as we did in Wave)

As soon as the golive branch is in production we can replace the skribble.com based url font with the static file from videoident.me.