### PR TITLE
[WIP] Make font 'optional' to speed up first render

### DIFF
--- a/assets/sass/base.sass
+++ b/assets/sass/base.sass
@@ -3,14 +3,14 @@
   src: url('../fonts/woff2/averta-regular.woff2') format('woff2'), url('../fonts/woff/hinted-averta-regular.woff') format('woff')
   font-weight: 400
   font-style: normal
-  font-display: fallback
+  font-display: optional
 
 @font-face
   font-family: Averta
   src: url('../fonts/woff2/averta-extra-bold.woff2') format('woff2'), url('../fonts/woff/hinted-averta-extrabold.woff') format('woff')
   font-weight: 800
   font-style: normal
-  font-display: fallback
+  font-display: optional
 
 @import 'vars'
 @import 'mixins'


### PR DESCRIPTION
The browser can continue to download the font in the background
so on later visits it will be used immediately, but on first visit we
avoid a "flash" when the font has arrived.