### PR TITLE
[MRG] Add hint to name fields

### DIFF
--- a/locales/de_CH.js
+++ b/locales/de_CH.js
@@ -109,6 +109,7 @@ export default {
       first_name: 'Vorname',
       last_name: 'Nachname',
       name_is_required: 'Name wird benötigt',
+      name_hint: 'Wie im Ausweis aufgeführt',
       pay_now: 'Jetzt bezahlen',
       terms: 'Es gelten die {0} von Skribble.',
       terms_linkText: 'Datenschutzrichtlinien',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -197,6 +197,7 @@
                             v-model="firstName"
                             :rules="nameRules"
                             :label="$t('payment.form.first_name')"
+                            :hint="$t('payment.form.name_hint')"
                             autocomplete="given-name"
                             required
                             outlined
@@ -208,6 +209,7 @@
                             :rules="nameRules"
                             :label="$t('payment.form.last_name')"
                             autocomplete="family-name"
+                            :hint="$t('payment.form.name_hint')"
                             required
                             outlined
                           ></v-text-field>


### PR DESCRIPTION
The hint suggests that the first and last name have to be as in the
passport of the user.

I modified the locales file by hand because I couldn't find the right export option in lokalise. Only found one option that would make a `.js` but it had a different structure from what we have in the repo. If someone knows/has a screenshot of the settings I'll add it to the README so next time we know what to do.