### PR TITLE
[MRG] Switch to using EUR as currency

### DIFF
--- a/components/ThePaymentForm.vue
+++ b/components/ThePaymentForm.vue
@@ -352,6 +352,7 @@ export default Vue.extend({
           return await this.$axios.$post('/api/setup_payment', {
             email: this.email,
             country: this.country,
+            currency: 'eur',
           })
         } catch (error) {
           this.status = 'error-during-payment'

--- a/components/ThePaymentForm.vue
+++ b/components/ThePaymentForm.vue
@@ -42,8 +42,6 @@
           ]"
         >
           <strong>{{ $t('payment.price_info1') }}</strong>
-          {{ $t('payment.price_info2') }}
-          <br />
         </div>
         <!-- Form -->
         <div class="pay__flex">

--- a/locales/de_CH.js
+++ b/locales/de_CH.js
@@ -116,8 +116,7 @@ export default {
       terms_linkURL: 'https://www.skribble.com/de/datenschutz/',
       you_must_agree: 'Sie müssen zustimmen, um den Prozess zu starten.',
     },
-    price_info1:
-      'Sie profitieren für begrenzte Zeit vom Vorzugspreis von CHF 19.–',
+    price_info1: 'Der Preis für die Video-Identifikation beträgt EUR 15.–',
     price_info2: '(regulärer Preis: CHF 25.–)',
     price_info3:
       'Die Identifikation kann derzeit auf Deutsch durchgeführt werden.',


### PR DESCRIPTION
This sends the currency the client wants to pay in to seven. Right now using this to help test the switch to Euro. After that we can either remove this request parameter or keep it with half an eye towards allowing both CHF and EUR in the UI.

Before this PR can be deployed we need to have https://github.com/BlockSigner/seven/pull/21 on production and finish all other tasks related to the switch (cove, marketing material, etc).